### PR TITLE
Bump tape from 5.8.1 to 5.9.0 in the development-dependencies group (…

### DIFF
--- a/.github/workflows/melinda-node-tests.yml
+++ b/.github/workflows/melinda-node-tests.yml
@@ -24,7 +24,7 @@ jobs:
         cache: 'npm'
       env:
         NPM_CONFIG_IGNORE_SCRIPTS: true
-    - run: npm i -g npm@latest
+    #- run: npm i -g npm@latest
     - run: npm audit --package-lock-only --production --audit-level=high
     - run: npm i
     - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1008,17 +1008,18 @@
       }
     },
     "node_modules/mock-property": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/mock-property/-/mock-property-1.0.3.tgz",
-      "integrity": "sha512-2emPTb1reeLLYwHxyVx993iYyCHEiRRO+y8NFXFPL5kl5q14sgTK76cXyEKkeKCHeRw35SfdkUJ10Q1KfHuiIQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mock-property/-/mock-property-1.1.0.tgz",
+      "integrity": "sha512-1/JjbLoGwv87xVsutkX0XJc0M0W4kb40cZl/K41xtTViBOD9JuFPKfyMNTrLJ/ivYAd0aPqu/vduamXO0emTFQ==",
       "dev": true,
       "dependencies": {
-        "define-data-property": "^1.1.1",
+        "define-data-property": "^1.1.4",
         "functions-have-names": "^1.2.3",
         "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0",
-        "hasown": "^2.0.0",
-        "isarray": "^2.0.5"
+        "has-property-descriptors": "^1.0.2",
+        "hasown": "^2.0.2",
+        "isarray": "^2.0.5",
+        "object-inspect": "^1.13.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1309,9 +1310,9 @@
       }
     },
     "node_modules/tape": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-5.8.1.tgz",
-      "integrity": "sha512-pUzADXBVYm5Jkneh9hfXnirADrzQrDA3vddKbPOc/ZLORj4dFQ6GR1KdGWX0/NvOLDcYkVgeMdw78Uf6BzO3KA==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-5.9.0.tgz",
+      "integrity": "sha512-czbGgxSVwRlbB3Ly/aqQrNwrDAzKHDW/kVXegp4hSFmR2c8qqm3hCgZbUy1+3QAQFGhPDG7J56UsV1uNilBFCA==",
       "dev": true,
       "dependencies": {
         "@ljharb/resumer": "^0.1.3",
@@ -1329,8 +1330,8 @@
         "inherits": "^2.0.4",
         "is-regex": "^1.1.4",
         "minimist": "^1.2.8",
-        "mock-property": "^1.0.3",
-        "object-inspect": "^1.13.1",
+        "mock-property": "^1.1.0",
+        "object-inspect": "^1.13.2",
         "object-is": "^1.1.6",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@natlibfi/issn-verify",
-  "version": "1.0.5",
+  "version": "1.0.6-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@natlibfi/issn-verify",
-      "version": "1.0.5",
+      "version": "1.0.6-alpha.1",
       "license": "MIT",
       "devDependencies": {
         "tape": "^5.8.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@natlibfi/issn-verify",
-  "version": "1.0.5",
+  "version": "1.0.6-alpha.1",
   "homepage": "https://github.com/malantonio/issn-verify-js",
   "bugs": {
     "url": "https://github.com/malantonio/issn-verify-js/issues"


### PR DESCRIPTION
…#16)

Bumps the development-dependencies group with 1 update: [tape](https://github.com/tape-testing/tape).


Updates `tape` from 5.8.1 to 5.9.0
- [Changelog](https://github.com/tape-testing/tape/blob/master/CHANGELOG.md)
- [Commits](https://github.com/tape-testing/tape/compare/v5.8.1...v5.9.0)

---
updated-dependencies:
- dependency-name: tape dependency-type: direct:development update-type: version-update:semver-minor dependency-group: development-dependencies ...